### PR TITLE
Fix "All Posts" link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
       </ul>
       
       <p><em><p>Some things I think.</p>
-<p><a href="./posts/"><strong>&mdash; All Posts &mdash;</strong></a></p>
+<p><a href="/blog/posts/"><strong>&mdash; All Posts &mdash;</strong></a></p>
 </em></p>
       
     </header>


### PR DESCRIPTION
Hey there! Just read your post on use statements and wanted to check out your other posts, only to find the link to the overview page broken! Right now it appends `/posts` to the current URL, whatever that is.